### PR TITLE
Add visible header to frontend

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -89,9 +89,14 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
+/* Header */
 header {
-    display: none;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border-color);
+    padding: 1.5rem 2rem;
+    text-align: center;
+    flex-shrink: 0;
+    box-shadow: var(--shadow);
 }
 
 header h1 {
@@ -871,6 +876,7 @@ details[open] .suggested-header::before {
 /* Theme transition for smooth color changes */
 body,
 .container,
+header,
 .sidebar,
 .chat-main,
 .chat-container,
@@ -893,6 +899,7 @@ body,
     .theme-toggle .moon-icon,
     body,
     .container,
+    header,
     .sidebar,
     .chat-main,
     .chat-container,


### PR DESCRIPTION
Fixes #2

This PR adds a visible header to the frontend that matches the current theme.

### Changes
- Made header visible (was previously hidden with `display: none`)
- Styled with theme colors using CSS variables
- Added border and shadow for visual consistency
- Ensured smooth transitions for light/dark theme toggle
- Header uses existing gradient logo design

Generated with [Claude Code](https://claude.ai/code)